### PR TITLE
correct README with missing quotes in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var config = {
 		        ],
                 avoidHighways: false,
                 avoidTolls: false,
-                mode: DRIVING,
+                mode: 'DRIVING',
                 language: "en-EN",
                 offsetTime: 25,
                 debug: false


### PR DESCRIPTION
missing quotes