### PR TITLE
increasing the connectivity timeout for google maps api from 1s to 3s

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -39,7 +39,7 @@ module.exports = NodeHelper.create({
 			language: config.language };
 
 		var response = await client.distancematrix({ params: request,
-			timeout: 1000 }).then((response) => {
+			timeout: 3000 }).then((response) => {
 			response.data.rows[0].elements.forEach((element) => {
 				if (config.debug) Log.info(`Module ${this.name}: response -> ${JSON.stringify(element)}.`);
 			});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/Jacopo1891/MMM-GoogleTrafficTimes#readme",
   "dependencies": {
-    "@googlemaps/google-maps-services-js": "^3.3.42"
+    "@googlemaps/google-maps-services-js": "^3.3.42",
+    "core-js":"^3.37.1"
   }
 }


### PR DESCRIPTION
devices with poor connectivity (ie. wifi) that also have poor internet can sometimes have greater than 1000ms+ responses from google maps api.

Tripling this value should give it better versatility.