### PR TITLE
Fix duration for drive mode and use schedule to show static or withTraffic time, static outside of schedule to avoid confusion

### DIFF
--- a/MMM-GoogleTrafficTimes.js
+++ b/MMM-GoogleTrafficTimes.js
@@ -168,8 +168,8 @@ Module.register("MMM-GoogleTrafficTimes", {
 		}
 
 		var firstLineText = document.createElement("span");
-		if (self.config.mode === TravelModes.DRIVE) firstLineText.innerHTML = response.localizedValues.staticDuration.text;
-		else firstLineText.innerHTML = response.localizedValues.duration.text;
+		if (self.config.mode === TravelModes.DRIVE && self.isScheduledNow()) firstLineText.innerHTML = response.localizedValues.duration.text;
+		else firstLineText.innerHTML = response.localizedValues.staticDuration.text;
 		firstLineDiv.appendChild(firstLineText);
 		container.appendChild(firstLineDiv);
 

--- a/MMM-GoogleTrafficTimes.js
+++ b/MMM-GoogleTrafficTimes.js
@@ -34,6 +34,7 @@ Module.register("MMM-GoogleTrafficTimes", {
 		timeLastUpdateWarning: 1,
 		horizontalLayout: false,
 		schedules: [],
+		showTrafficTimesOutsideOfSchedule: false,
 		debug: false
 	},
 
@@ -229,7 +230,11 @@ Module.register("MMM-GoogleTrafficTimes", {
 		if (self.config.debug) Log.info(`Module ${self.name}: inside getDom.`);
 		var wrapper = document.createElement("div");
 		if (self.config.horizontalLayout) wrapper.className = "mmmtraffic-horizontaly";
-		self.getContent(wrapper);
+		if (self.config.showTrafficTimesOutsideOfSchedule) {
+			self.getContent(wrapper);
+		} else if (self.isScheduledNow()) {
+			self.getContent(wrapper);
+		}
 		return wrapper;
 	}
 });

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ var config = {
                 timeLastUpdateWarning: 1,
                 horizontalLayout: false,
                 schedules: [],
+		        showTrafficTimesOutsideOfSchedule: false,
                 debug: false
             },
         }
@@ -85,6 +86,7 @@ var config = {
 * `timeLastUpdateWarning`: Specifies time (in minutes) that have to elapse since last failed data update to display the warning message. (Default 1 minute.)
 * `horizontalLayout`: true or false, Organize results on horizonal line. (Default false.)
 * `schedules`: parameter accepts an array of objects, each representing a schedule for content display (Default empty -> the module will be displayed at all times)
+* `showTrafficTimesOutsideOfSchedule`: true or false, shows the traffic times even if current time not in any schedule. (Default false)
 * `debug`: true or false, shows logs on console (node_helper -> backend, module -> browser).
 
 The Destinations with full address (Street , City, Country) need to be entered in the form


### PR DESCRIPTION
I think I've made a mistake on my earlier PR and forgot to switch the staticDuration and the duration with traffic so here is a fix for that. Also to avoid confusion during outside of schedule times we show the static duration outside of the schedule instead of the last known duration with traffic